### PR TITLE
[MainGameVR] POV addition

### DIFF
--- a/MainGameVR/Camera/POV.cs
+++ b/MainGameVR/Camera/POV.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using VRGIN.Controls;
+using VRGIN.Core;
+using VRGIN.Helpers;
+using KKS_VR.Settings;
+
+
+public enum POV_MODE
+{
+    // Press Key (default: Y) to change POV Mode, configurable in BepInEX Plugin Settings (F1)
+    EYE = 0,      // Mode1: Tracking Eye Position (Default)
+    TELEPORT = 1, // Mode2: Teleport(Jump) to next character when trigger controller
+}
+
+namespace KKS_VR.Camera
+{
+    internal class POV : ProtectedBehaviour
+    {
+        private Controller _leftController, _rightController;
+
+        private ChaControl _currentChara;
+
+        private POV_MODE _povMode;
+
+        private bool _active;
+
+        private KoikatuSettings _settings;
+
+        public void Initialize(Controller left, Controller right)
+        {
+            _leftController = left;
+            _rightController = right;
+        }
+
+        public bool IsActive()
+        {
+            return _active;
+        }
+
+        protected override void OnAwake()
+        {
+            base.OnAwake();
+            // HScene Init
+            _currentChara = null;
+
+            _povMode = POV_MODE.EYE;
+
+            _active = false;
+
+            _settings = VR.Context.Settings as KoikatuSettings;
+        }
+
+        private Transform GetHead(ChaControl human)
+        {
+            return human.objHead.GetComponentsInParent<Transform>().First((Transform t) => t.name.StartsWith("c") && t.name.ToLower().Contains("j_head"));
+        }
+        private Transform GetEyePose(ChaControl human)
+        {
+            Transform transform = human.objHeadBone.transform.Descendants().FirstOrDefault((Transform t) => t.name.StartsWith("c") && t.name.ToLower().EndsWith("j_faceup_tz"));
+            if (transform == null)
+            {
+                VRLog.Info("Creating eyes, {0}", human.name);
+                transform = new GameObject("cf_j_faceup_tz").transform;
+                transform.SetParent(GetHead(human), false);
+                transform.transform.localPosition = new Vector3(0f, 0.07f, 0.05f);
+            }
+            return transform;
+        }
+
+        private void UpdateCurrentChara(List<ChaControl> targets)
+        {
+            // Rotate targets only when currentCharaIdx is found and it is not the last element already
+            int currentCharaIdx = targets.IndexOf(_currentChara);
+            if (currentCharaIdx > -1 && currentCharaIdx < targets.Count - 1)
+            {
+                // Rotate the list using LINQ
+                var rotated = targets.Skip(currentCharaIdx + 1).Concat(targets.Take(currentCharaIdx + 1)).ToList();
+                targets.Clear();
+                targets.AddRange(rotated);
+            }
+
+            foreach (var target in targets)
+            {
+                if (target.sex == 1) // 1 is female, only choose male as target
+                    continue;
+
+                // Set Camera to Character Eye
+                var targetEyePose = GetEyePose(target);
+                var tvec = targetEyePose.position;
+                var quat = Quaternion.Euler(0, targetEyePose.rotation.eulerAngles.y, 0);
+                VRManager.Instance.Mode.MoveToPosition(tvec, quat, false);
+                VRLog.Info("POV target found, {0}", target.name);
+                _currentChara = target;
+                return;
+            }
+        }
+
+        private void SetPOV()
+        {
+            if (_currentChara == null) return;
+
+            switch (_povMode)
+            {
+                case POV_MODE.EYE:
+                    VRManager.Instance.Mode.MoveToPosition(GetEyePose(_currentChara).position, false);
+                    break;
+                case POV_MODE.TELEPORT:
+                default:
+                    break;
+            }
+        }
+
+        protected override void OnUpdate()
+        {
+            if (_settings.EnablePOV == false) return;
+            // Press Key (default: Y) to change POV Mode, configurable in BepInEX Plugin Settings (F1)
+            if (POVConfig.switchPOVModeKey.Value.IsDown())
+            {
+                _povMode = (POV_MODE)(((int)_povMode + 1) % Enum.GetValues(typeof(POV_MODE)).Length);
+                VRLog.Info("Switching to POV_MODE {0}", (int)_povMode);
+            }
+
+            var isControllerActive =
+                (VR.Mode.Left.ToolIndex == 2 && VR.Mode.Left.ActiveTool.isActiveAndEnabled) ||
+                (VR.Mode.Right.ToolIndex == 2 && VR.Mode.Right.ActiveTool.isActiveAndEnabled);
+            var isTriggered =
+                _leftController.Input.GetPressDown(Valve.VR.EVRButtonId.k_EButton_SteamVR_Trigger) ||
+                _rightController.Input.GetPressDown(Valve.VR.EVRButtonId.k_EButton_SteamVR_Trigger);
+
+            // When left | right hand controller is Hand Tool and visible
+            if (isControllerActive && isTriggered)
+            {
+                // Press VR Trigger button to set _active
+                if (!_active)
+                {
+                    _active = true;
+                }
+                List<ChaControl> targets = GameObject.FindObjectsOfType<ChaControl>().ToList();
+                UpdateCurrentChara(targets);
+            }
+            // When there is no Hand Tool, deactive
+            else if (_active && VR.Mode.Left.ToolIndex != 2 && VR.Mode.Right.ToolIndex != 2)
+            {
+                _active = false;
+            }
+
+            // Only update POV if active
+            if (_active)
+            {
+                SetPOV();
+            }
+        }
+    }
+}

--- a/MainGameVR/Caress/CaressController.cs
+++ b/MainGameVR/Caress/CaressController.cs
@@ -32,6 +32,11 @@ namespace KKS_VR.Caress
         private KoikatuSettings _settings;
         private bool _triggerPressed; // Whether the trigger is currently pressed. false if _lock is null.
 
+        public Controller getController()
+        {
+            return _controller;
+        }
+
         protected override void OnAwake()
         {
             base.OnAwake();

--- a/MainGameVR/Interpreters/HSceneInterpreter.cs
+++ b/MainGameVR/Interpreters/HSceneInterpreter.cs
@@ -8,12 +8,19 @@ namespace KKS_VR.Interpreters
         private bool _active;
         private HSceneProc _proc;
         private Caress.VRMouth _vrMouth;
+        private Caress.CaressController _leftController;
+        private Caress.CaressController _rightController;
+        private Camera.POV _pov;
 
         private Color _currentBackgroundColor;
         private bool _currentShowMap;
 
         public override void OnStart()
         {
+            _leftController = VR.Mode.Left.gameObject.AddComponent<Caress.CaressController>();
+            _rightController = VR.Mode.Left.gameObject.AddComponent<Caress.CaressController>();
+            _pov = VR.Camera.gameObject.AddComponent<Camera.POV>();
+            _pov.Initialize(_leftController.getController(), _rightController.getController());
             _currentBackgroundColor = Manager.Config.HData.BackColor;
             _currentShowMap = Manager.Config.HData.Map;
             UpdateCameraState();
@@ -22,13 +29,17 @@ namespace KKS_VR.Interpreters
         public override void OnDisable()
         {
             Deactivate();
+            Object.Destroy(_pov);
+            Object.Destroy(_leftController);
+            Object.Destroy(_rightController);
         }
 
         public override void OnUpdate()
         {
             if (_currentShowMap != Manager.Config.HData.Map || _currentBackgroundColor != Manager.Config.HData.BackColor)
             {
-                UpdateCameraState();
+                if (!_active || !_pov.IsActive())
+                    UpdateCameraState();
             }
 
             if (_active && (!_proc || !_proc.enabled))
@@ -42,7 +53,6 @@ namespace KKS_VR.Interpreters
                 proc.enabled)
             {
                 _vrMouth = VR.Camera.gameObject.AddComponent<Caress.VRMouth>();
-                AddControllerComponent<Caress.CaressController>();
                 _proc = proc;
                 _active = true;
             }
@@ -54,7 +64,6 @@ namespace KKS_VR.Interpreters
             {
                 VR.Camera.SteamCam.camera.clearFlags = CameraClearFlags.Skybox;
                 Object.Destroy(_vrMouth);
-                DestroyControllerComponent<Caress.CaressController>();
                 _proc = null;
                 _active = false;
             }

--- a/MainGameVR/MainGameVR.csproj
+++ b/MainGameVR/MainGameVR.csproj
@@ -237,6 +237,7 @@
     <Compile Include="VRPlugin.cs" />
     <Compile Include="Controls\GameplayTool.cs" />
     <Compile Include="Settings\KoikatuSettings.cs" />
+    <Compile Include="Camera\POV.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/MainGameVR/Settings/KoikatuSettings.cs
+++ b/MainGameVR/Settings/KoikatuSettings.cs
@@ -126,6 +126,18 @@ namespace KKS_VR.Settings
         }
 
         private float _NearClipPlane;
+
+        public bool EnablePOV
+        {
+            get => _EnablePOV;
+            set
+            {
+                _EnablePOV = value;
+                TriggerPropertyChanged("EnablePOV");
+            }
+        }
+
+        private bool _EnablePOV = true;
     }
 
     public class KeySet

--- a/MainGameVR/Settings/SettingsManager.cs
+++ b/MainGameVR/Settings/SettingsManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using BepInEx.Configuration;
 using KKAPI.Utilities;
 using VRGIN.Core;
+using UnityEngine;
 
 namespace KKS_VR.Settings
 {
@@ -172,6 +173,8 @@ namespace KKS_VR.Settings
             keySetsConfig = new KeySetsConfig(config, updateKeySets);
             updateKeySets();
 
+            POVConfig pOVConfig = new POVConfig(config, settings);
+
             // Fixed settings
             settings.ApplyEffects = false; // We manage effects ourselves.
 
@@ -282,6 +285,33 @@ namespace KKS_VR.Settings
                 _right.Value,
                 _left.Value,
                 _center.Value);
+        }
+    }
+
+   public class POVConfig
+    {
+        private const string sectionPOV = "4. POV between characters (Hand Tool in free H)";
+        public static ConfigEntry<KeyboardShortcut> switchPOVModeKey { get; private set; }
+
+        public POVConfig(ConfigFile config, KoikatuSettings settings)
+        {
+            var enablePOV = config.Bind(sectionPOV, "POV", true,
+                "Switch POV between characters in free H scenes (only works in Hand Tool)");
+            Tie(enablePOV, v => settings.EnablePOV = v);
+
+            switchPOVModeKey = config.Bind(sectionPOV, "Switch POV Mode", new KeyboardShortcut(KeyCode.Y),
+                new ConfigDescription(
+                    "Use VR Trigger Button to switch POV between characters. " +
+                    "Two Modes:\r\n" +
+                    "1: POV follows character's head position with forward rotation once\r\n" +
+                    "2: No POV",
+                    null,
+                    new ConfigurationManagerAttributes { Order = -1 }));
+        }
+        private static void Tie<T>(ConfigEntry<T> entry, Action<T> set)
+        {
+            set(entry.Value);
+            entry.SettingChanged += (_, _1) => set(entry.Value);
         }
     }
 }


### PR DESCRIPTION
This should unnecessitate the PR #46 and #47 to be reviewed.
I checked the diff between the curren HEAD and [tony246642:master](https://github.com/tony246642/KK_MainGameVR/tree/master), POV related changes only lived inside the recent two commits.
[a45f616](https://github.com/IllusionMods/KKS_VR/pull/47/commits/a45f6166adbee753ccad3b1086d6aadbfd3e2b83) includes most of the implementation and I had to redo/simplify the logics, removing some of math/reason which I thought was not the best for me.
Since much of divergence between [KKS_VR](https://github.com/IllusionMods/KKS_VR) and [KK_MainGameVR](https://github.com/tony246642/KK_MainGameVR) is of path-changes as well as submodule packaging, rebasing the whole thing will basically require >10x more effort whereas what we want is to simply putting POV.

How to test
- once in H-scene after launching `KoikatsuSunshine.exe --vr`
- trigger button on Hand menu will enable POV
- if there is another male in the scene, each trigger will change POV target one by one
