### PR TITLE
Add auto hand attachment

### DIFF
--- a/Shared/Grasp/Parts/BodyPart.cs
+++ b/Shared/Grasp/Parts/BodyPart.cs
@@ -31,7 +31,7 @@ namespace KK_VR.Grasp
         //internal readonly KK_VR.IK.OffsetEffector offsetEffector;
         // Default component. We need it to not upset default code when animator changes state.
         internal readonly BaseData baseData;
-        internal State state;
+        private State _state;
         internal List<Collider> colliders = [];
         // Component responsible for moving and collider tracking.
         internal readonly PartGuide guide;
@@ -107,5 +107,10 @@ namespace KK_VR.Grasp
         // They are very cheap.. Limit IK on hidden targets instead, that stuff is VERY expensive.
         internal bool GetDefaultState() => name > PartName.ThighR;
         internal void Destroy() => GameObject.Destroy(guide.gameObject);
+
+        internal void AddState(State state) => _state |= state;
+        internal void RemoveState(State state) => _state &= ~state;
+        internal void ResetState(bool toDefault = false) => _state = toDefault ? State.Default : 0;
+        internal bool IsState(State state) => (_state & state) != 0;
     }
 }

--- a/Shared/Handlers/ForGrasp/BodyPartGuide.cs
+++ b/Shared/Handlers/ForGrasp/BodyPartGuide.cs
@@ -52,12 +52,8 @@ namespace KK_VR.Handlers
             _target = target;
             if (!_anchor.gameObject.activeSelf)
             {
-                //SetBodyPartCollidersToTrigger(true);
                 _anchor.gameObject.SetActive(true);
-                //transform.parent = _objAnim;
             }
-            //_bodyPart.effector.rotationWeight = 1f;
-            //_bodyPart.effector.target = _bodyPart.anchor;
             if (_bodyPart.goal != null && !_bodyPart.goal.IsBusy)
             {
                 _bodyPart.chain.bendConstraint.weight = KoikSettings.IKDefaultBendConstraint.Value;
@@ -75,7 +71,8 @@ namespace KK_VR.Handlers
             _offsetRot = Quaternion.Inverse(target.rotation) * _anchor.rotation;
             _offsetPos = target.InverseTransformPoint(_anchor.position);
 
-            _bodyPart.state = State.Grasped;
+            _bodyPart.ResetState();
+            _bodyPart.AddState(State.Active | State.Grasped);
 
             if (hand != null)
             {
@@ -92,9 +89,8 @@ namespace KK_VR.Handlers
             _hand = null;
             _follow = false;
             _attach = false;
-            //SetBodyPartCollidersToTrigger(false);
             _bodyPart.visual.Hide();
-            _bodyPart.state = State.Active;
+            _bodyPart.RemoveState(State.Grasped);
             ClearTracker();
         }
 
@@ -145,10 +141,12 @@ namespace KK_VR.Handlers
                 _translateEx = true;
                 _translateExOffset = _anchor.position - _bodyPart.afterIK.position;
             }
+            _follow = true;
             _attach = true;
             _target = target;
             _bodyPart.visual.Hide();
-            _bodyPart.state = State.Attached;
+            _bodyPart.RemoveState(State.Grasped);
+            _bodyPart.AddState(State.Attached);
 
 
             _offsetRot = Quaternion.Inverse(_target.rotation) * _anchor.rotation;
@@ -157,7 +155,8 @@ namespace KK_VR.Handlers
 
         internal void OnSyncStart()
         {
-            _bodyPart.state = State.Synced;
+            _bodyPart.ResetState();
+            _bodyPart.AddState(State.Synced);
             _translate = new Translate(_anchor, () => _effector.maintainRelativePositionWeight -= Time.deltaTime, () => _translate = null);
         }
 
@@ -205,32 +204,8 @@ namespace KK_VR.Handlers
         }
         private void LateUpdate()
         {
-            _effector.positionOffset += _anchor.position - _effector.bone.position; 
+            _effector.positionOffset += _anchor.position - _effector.bone.position;
         }
-
-        //private void FixedUpdate()
-        //{
-        //    //if (_unwind)
-        //    //{
-        //    //    _timer = Mathf.Clamp01(_timer - Time.deltaTime);
-        //    //    _rigidBody.velocity *= _timer;
-        //    //    if (_timer == 0f)
-        //    //    {
-        //    //        _unwind = false;
-        //    //    }
-        //    //}
-        //    if (_follow)
-        //    {
-        //        _rigidBody.MovePosition(_target.TransformPoint(_offsetPos));
-        //        _rigidBody.MoveRotation(_target.rotation * _offsetRot);
-
-        //        if (_translate)
-        //        {
-        //            TranslateOnFollow();
-        //        }
-        //    }
-        //}
-
     }
 }
 

--- a/Shared/Handlers/ForGrasp/HeadPartGuide.cs
+++ b/Shared/Handlers/ForGrasp/HeadPartGuide.cs
@@ -31,7 +31,9 @@ namespace KK_VR.Handlers
             _target = target;
 
             //if (KoikGame.Settings.ShowGuideObjects) _bodyPart.visual.Show();
-            _bodyPart.state = State.Grasped;
+
+            _bodyPart.ResetState();
+            _bodyPart.AddState(State.Active | State.Grasped);
 
             _offsetRot = Quaternion.Inverse(target.rotation) * _anchor.rotation;
             _offsetPos = target.InverseTransformPoint(_anchor.position);

--- a/Shared/Handlers/ForGrasp/PartGuide.cs
+++ b/Shared/Handlers/ForGrasp/PartGuide.cs
@@ -110,7 +110,6 @@ namespace KK_VR.Handlers
         /// </summary>
         internal void Sleep(bool instant)
         {
-            BodyPart.state = Grasp.GraspController.State.Active;
             _hand = null;
             _follow = false;
             _attach = false;
@@ -122,7 +121,8 @@ namespace KK_VR.Handlers
             }
             else
             {
-                BodyPart.state = Grasp.GraspController.State.Translation;
+                BodyPart.ResetState();
+                BodyPart.AddState(Grasp.GraspController.State.Translation);
                 _translate = new(_anchor, null, Disable);
             }
             BodyPart.visual.Hide();
@@ -140,7 +140,7 @@ namespace KK_VR.Handlers
             {
                 BodyPart.chain.bendConstraint.weight = 1f;
             }
-            BodyPart.state = Grasp.GraspController.State.Default;
+            BodyPart.ResetState(toDefault: true);
             _anchor.gameObject.SetActive(BodyPart.GetDefaultState());
         }
 

--- a/Shared/Handlers/Trackers/Tracker.cs
+++ b/Shared/Handlers/Trackers/Tracker.cs
@@ -20,6 +20,22 @@ namespace KK_VR.Handlers
         protected Dictionary<ChaControl, List<Body>> _blacklistDic;
         protected readonly List<Collider> _trackList = [];
         internal ColliderInfo colliderInfo;
+
+        /// <summary>
+        /// Checks if the collider is in use.
+        /// </summary>
+        internal static bool IsColliderPresent(Collider collider, out ChaControl chara)
+        {
+            if (_referenceTrackDic.ContainsKey(collider))
+            {
+                chara = _referenceTrackDic[collider].chara;
+                return true;
+            }
+            chara = null;
+            return false;
+        }       
+
+
         internal void SetBlacklistDic(Dictionary<ChaControl, List<Body>> dic)
         {
             _blacklistDic = dic;

--- a/Shared/Settings/KoikSettings.cs
+++ b/Shared/Settings/KoikSettings.cs
@@ -128,6 +128,7 @@ namespace KK_VR.Settings
         public static ConfigEntry<float> IKDefaultBendConstraint { get; private set; }
 
         public static ConfigEntry<bool> IKReturnBodyPartAfterSync { get; private set; }
+        public static ConfigEntry<bool> IKAutoHandAttachment { get; private set; }
 
         #endregion
 
@@ -409,6 +410,14 @@ namespace KK_VR.Settings
                     "Return limb to the default state when sync stops.",
                     null,
                     new ConfigurationManagerAttributes { Order = -8 }
+                    ));
+
+
+            IKAutoHandAttachment = config.Bind(SectionIK, "Auto hand attachment", true,
+                new ConfigDescription(
+                    "Attempt sneaky hand attachment to a partner every time animation controller changes state.",
+                    null,
+                    new ConfigurationManagerAttributes { Order = -12 }
                     ));
 
 

--- a/SharedGame/Interpreters/KoikGameInterp.cs
+++ b/SharedGame/Interpreters/KoikGameInterp.cs
@@ -9,6 +9,7 @@ using KK_VR.Holders;
 using System;
 using KK_VR.Controls;
 using BepInEx;
+using KKAPI.Utilities;
 
 namespace KK_VR.Interpreters
 {
@@ -360,15 +361,20 @@ namespace KK_VR.Interpreters
         {
             return Mathf.CeilToInt(_targetFps / Time.deltaTime * number);
         }
-        internal static void RunAfterUpdate(Action action)
+
+        internal static void RunAfterUpdate(Action action, bool onEndFrame = false, int numberOfUpdates = 1)
         {
-            _instance.StartCoroutine(_instance.RunAfterUpdateCo(action));
+            _instance.StartCoroutine(RunAfterUpdateCo(action, onEndFrame, numberOfUpdates));
         }
-        private IEnumerator RunAfterUpdateCo(Action action)
+
+        private static IEnumerator RunAfterUpdateCo(Action action, bool onEndFrame, int numberOfUpdates)
         {
-            yield return null;
+            var ret = onEndFrame ? CoroutineUtils.WaitForEndOfFrame : null;
+            while (numberOfUpdates-- > 0)
+            {
+                yield return ret;
+            }
             action.Invoke();
         }
-        
     }
 }


### PR DESCRIPTION
Add setting to automatically sneakily attach hands to partners when in direct proximity through IK. 

Works only when the hand is in default state, and provides much better hand position then native way where all is based on animation. Attempts are made during change of animation controller or change of its state.