### PR TITLE
PoV adjustments

### DIFF
--- a/Shared/Camera/Pov.cs
+++ b/Shared/Camera/Pov.cs
@@ -181,7 +181,13 @@ namespace KK_VR.Features
 
             var hair = chara.objHeadBone.transform.Find("ct_head/N_tonn_face/N_cf_haed");
 
-            if (hair != null)
+            if (hair != null
+#if KK
+                && !hair.gameObject.active)
+#else
+                && !hair.gameObject.activeSelf)
+#endif
+
                 hair.gameObject.SetActive(true);
         }
 
@@ -569,7 +575,9 @@ namespace KK_VR.Features
             _hideHead = false;
             _moveTo = null;
 
-            Impersonation?.Invoke(false, _target);
+            if (_target != null)
+                Impersonation?.Invoke(false, _target);
+
             CameraBusy?.Invoke(false);
             //MouthGuide.SetBusy(false);
             //if (IntegrationMaleBreath.IsActive)
@@ -634,6 +642,12 @@ namespace KK_VR.Features
         {
             if (_active)
             {
+                // Chara destroyed, emergency halt
+                if (_target == null)
+                {
+                    Sleep();
+                    return;
+                }
                 if (KoikGameInterp.SceneInput.IsBusy// || _mouth.IsActive
 #if KK
                     || !Scene.Instance.AddSceneName.Equals("HProc"))
@@ -668,7 +682,7 @@ namespace KK_VR.Features
 
         private void LateUpdate()
         {
-            if (_hideHead && _target != null)
+            if (_hideHead)
             {
                 //if (_hideHeadSetting == KoikSettings.PovHideHeadType.ShowHair)
                 //{
@@ -686,7 +700,7 @@ namespace KK_VR.Features
                         // Hide only face
                         HideFace(_target, _targetFaceRenderers);
 
-                        if (_prevTarget != null)
+                        if (_prevTarget != null && _prevTargetFaceRenderers != null)
                             HideFace(_prevTarget, _prevTargetFaceRenderers);
                         break;
                     default:
@@ -717,21 +731,21 @@ namespace KK_VR.Features
                 }
             }
         }
-        private void HideFace(ChaControl chara, GameObject headRenderers)
+        private void HideFace(ChaControl chara, GameObject faceRenderers)
         {
             var headClose = IsHeadClose(chara.objHead.transform);
             // Doubt that it's a good idea to spam GameObject.SetActive() each frame in old Unity
 #if KK
-            if (headRenderers.active)
+            if (faceRenderers.active)
 #else
-            if (headRenderers.activeSelf)
+            if (faceRenderers.activeSelf)
 #endif
             {
-                if (headClose) headRenderers.SetActive(false);
+                if (headClose) faceRenderers.SetActive(false);
             }
             else
             {
-                if (!headClose) headRenderers.SetActive(true);
+                if (!headClose) faceRenderers.SetActive(true);
             }
         }
 

--- a/Shared/Camera/SmoothMover.cs
+++ b/Shared/Camera/SmoothMover.cs
@@ -29,7 +29,7 @@ namespace KK_VR.Camera
         internal void MoveToPoV()
         {
             var mode = HSceneInterp.mode;
-            if (PoV.Active || (KoikSettings.PovAutoEnter.Value && (mode == HFlag.EMode.houshi || mode == HFlag.EMode.sonyu)))
+            if (PoV.Active || ((KoikSettings.Pov.Value & KoikSettings.PovGenders.Auto) != 0 && (mode == HFlag.EMode.houshi || mode == HFlag.EMode.sonyu)))
             {
                 PoV.Instance.TryDisable(moveTo: false);
                 StartCoroutine(WaitForLag(PoV.Instance.StartPov, null));
@@ -40,7 +40,7 @@ namespace KK_VR.Camera
             //VRPlugin.Logger.LogDebug("VRMoverH:MoveToInH");
             StopAllCoroutines();
             var mode = HSceneInterp.mode;
-            if (PoV.Active || (KoikSettings.PovAutoEnter.Value && (mode == HFlag.EMode.houshi || mode == HFlag.EMode.sonyu)))
+            if (PoV.Active || ((KoikSettings.Pov.Value & KoikSettings.PovGenders.Auto) != 0 && (mode == HFlag.EMode.houshi || mode == HFlag.EMode.sonyu)))
             {
                 PoV.Instance.TryDisable(moveTo: false);
                 if (spotChange)

--- a/Shared/Settings/KoikSettings.cs
+++ b/Shared/Settings/KoikSettings.cs
@@ -39,9 +39,10 @@ namespace KK_VR.Settings
         }
         public enum PovHideHeadType
         {
-            Show,
-            Hide,
-            ForceHide
+            ShowHead,
+            HideHead,
+            HideHeadAlways,
+            HideFace,
         }
         public enum HeadEffector
         {
@@ -109,13 +110,11 @@ namespace KK_VR.Settings
 
         #region Pov
 
-        public static ConfigEntry<Genders> Pov { get; private set; }
+        public static ConfigEntry<PovGenders> Pov { get; private set; }
         public static ConfigEntry<PovMovementType> FlyInPov { get; private set; }
         public static ConfigEntry<PovHideHeadType> PovHideHead { get; private set; }
         public static ConfigEntry<float> FlightSpeed { get; private set; }
         public static ConfigEntry<int> PovDeviationThreshold { get; private set; }
-        public static ConfigEntry<bool> PovAutoEnter { get; private set; }
-        public static ConfigEntry<bool> PovNoRotation { get; private set; }
         public static ConfigEntry<PovAttachmentBones> PovAttachment { get; private set; }
 
 
@@ -328,28 +327,32 @@ namespace KK_VR.Settings
             #region SectionPov
 
 
-            Pov = config.Bind(SectionPov, "Enable", Genders.Boys,
+            Pov = config.Bind(SectionPov, "Enable", PovGenders.Boys | PovGenders.Auto | PovGenders.Rotation,
                 new ConfigDescription(
-                    "The range of targets for impersonations.",
+                    "Boys – target males for impersonation\n" +
+                    "Girls – target females for impersonation\n" +
+                    "Auto – automatically initiate PoV mode when appropriate\n" +
+                    "Rotation – follow rotation during PoV mode (might be dangerous for the first-day-vr-crew)\n" +
+                    "Climax – continue following during climax (causes violent trembles of the camera)",
                     null,
                     new ConfigurationManagerAttributes { Order = 100 }
                     ));
 
 
-            PovAutoEnter = config.Bind(SectionPov, "Auto impersonation", true,
-                new ConfigDescription(
-                    "Automatically impersonate on position change if appropriate according to the setting.",
-                    null,
-                    new ConfigurationManagerAttributes { Order = 90 }
-                    ));
+            //PovAutoEnter = config.Bind(SectionPov, "Auto impersonation", true,
+            //    new ConfigDescription(
+            //        "Automatically impersonate on position change if appropriate according to the setting.",
+            //        null,
+            //        new ConfigurationManagerAttributes { Order = 90 }
+            //        ));
 
 
-            PovNoRotation = config.Bind(SectionPov, "No rotation", false,
-                new ConfigDescription(
-                    "Disable rotation adjustment.",
-                    null,
-                    new ConfigurationManagerAttributes { Order = 80 }
-                    ));
+            //PovNoRotation = config.Bind(SectionPov, "No rotation", false,
+            //    new ConfigDescription(
+            //        "Disable rotation adjustment.",
+            //        null,
+            //        new ConfigurationManagerAttributes { Order = 80 }
+            //        ));
 
 
             PovDeviationThreshold = config.Bind(SectionPov, "Lazy", 15,
@@ -379,11 +382,12 @@ namespace KK_VR.Settings
                     ));
 
 
-            PovHideHead = config.Bind(SectionPov, "Hide head", PovHideHeadType.Hide,
+            PovHideHead = config.Bind(SectionPov, "Hide head", PovHideHeadType.HideHead,
                 new ConfigDescription(
-                    "Hide - hides character's head when the PoV camera is in it\n" +
-                    "Force Hide - always hides character's head. Behaves like 'Hide' option during GripMove\n" +
-                    "Show - character's head stays visible",
+                    "Show Head – never hide the head nor the face\n" +
+                    "Hide Head – hide the head when the camera is close to it\n" +
+                    "Hide Head Always – always hide the head\n" +
+                    "Hide Face – hide the face when the camera is close to it, leaves the hair and accessories visible",
                     null,
                     new ConfigurationManagerAttributes { Order = 40 }
                     ));
@@ -394,6 +398,13 @@ namespace KK_VR.Settings
                     null,
                     new ConfigurationManagerAttributes { Order = 30 }
                     ));
+
+            //PovStopForClimax = config.Bind(SectionPov, "Stop for climax", true,
+            //    new ConfigDescription(
+            //        "Halt position and rotation adjustment during climax to avoid violent trembling.",
+            //        null,
+            //        new ConfigurationManagerAttributes { Order = 20 }
+            //        ));
 
 
             // Didn't meet the expectations.
@@ -645,6 +656,17 @@ namespace KK_VR.Settings
                     }
                     break;
             }
+        }
+
+        [Flags]
+        public enum PovGenders
+        {
+            Disable = 0,
+            Boys = 1,
+            Girls = 2,
+            Auto = 4,
+            Rotation = 8,
+            Climax = 16,
         }
     }
 }

--- a/SharedGame/Interpreters/Patches/HScenePatches.cs
+++ b/SharedGame/Interpreters/Patches/HScenePatches.cs
@@ -161,5 +161,13 @@ namespace KK_VR.Patches
                 GraspHelper.Instance.CatchHitReaction(solver, __instance.current, (int)__instance.effector);
             }
         }
+
+        // Hook for the monitoring of animator's state during H
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(HActionBase), nameof(HActionBase.SetPlay))]
+        public static void SetPlayPostfix(string _nextAnimation)
+        {
+            if (PoV.Instance != null) PoV.Instance.OnSetPlay(_nextAnimation);
+        }
     }
 }

--- a/SharedGame/Interpreters/Scenes/HSceneInterp.cs
+++ b/SharedGame/Interpreters/Scenes/HSceneInterp.cs
@@ -146,7 +146,7 @@ namespace KK_VR.Interpreters
             {
                 GameSettings.UpdateShadowSetting(GameSettings.ShadowType.Close);
             }
-            if (GameSettings.PovAutoEnter.Value)
+            if ((GameSettings.Pov.Value & KoikSettings.PovGenders.Auto) != 0)
             {
                 SmoothMover.Instance.MoveToPoV();
             }


### PR DESCRIPTION
**PoV mode adjustments**
* Add setting to hide only face, leaving hair and accessories visible for the sake of immersion or whatever.
* Condense some of the PoV settings into [Flags] enum. Thanks for this awesome config representation.
* Add harmony hook to check current state of the animator only when it changes instead of on each frame.