### PR TITLE
[MainGame] Reset camera in roaming more often

### DIFF
--- a/SharedGame/Interpreters/Scenes/ActionSceneInterp.cs
+++ b/SharedGame/Interpreters/Scenes/ActionSceneInterp.cs
@@ -15,6 +15,7 @@ using ADV.Commands.Object;
 using WindowsInput.Native;
 using KK_VR.Holders;
 using UnityEngine.SceneManagement;
+using KKAPI.MainGame;
 
 namespace KK_VR.Interpreters
 {
@@ -50,6 +51,10 @@ namespace KK_VR.Interpreters
             {
                 KoikSettings.UpdateShadowSetting(KoikSettings.ShadowType.Average);
             }
+
+            GameAPI.PeriodChange += (_, _1) => OnReload();
+            GameAPI.DayChange += (_, _1) => OnReload();
+
             base.OnStart();
         }
 
@@ -60,11 +65,21 @@ namespace KK_VR.Interpreters
             HandHolder.SetKinematic(false);
             //ResetState();
             EnableCameraSystem();
+
+            GameAPI.PeriodChange -= (_, _1) => OnReload();
+            GameAPI.DayChange -= (_, _1) => OnReload();
         }
+
         internal override void OnSceneLoaded(UnityEngine.SceneManagement.Scene scene, LoadSceneMode mode)
+        {
+            OnReload();
+        }
+
+        private void OnReload()
         {
             _resetCamera = true;
         }
+
         internal override void OnUpdate()
         {
             if (_resetCamera)

--- a/SharedGame/Interpreters/Scenes/ActionSceneInterp.cs
+++ b/SharedGame/Interpreters/Scenes/ActionSceneInterp.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using VRGIN.Core;
 using StrayTech;
 using KK_VR.Settings;

--- a/SharedGame/Interpreters/Scenes/ActionSceneInterp.cs
+++ b/SharedGame/Interpreters/Scenes/ActionSceneInterp.cs
@@ -52,8 +52,8 @@ namespace KK_VR.Interpreters
                 KoikSettings.UpdateShadowSetting(KoikSettings.ShadowType.Average);
             }
 
-            GameAPI.PeriodChange += (_, _1) => OnReload();
-            GameAPI.DayChange += (_, _1) => OnReload();
+            GameAPI.PeriodChange += OnReload;
+            GameAPI.DayChange += OnReload;
 
             base.OnStart();
         }
@@ -66,16 +66,16 @@ namespace KK_VR.Interpreters
             //ResetState();
             EnableCameraSystem();
 
-            GameAPI.PeriodChange -= (_, _1) => OnReload();
-            GameAPI.DayChange -= (_, _1) => OnReload();
+            GameAPI.PeriodChange -= OnReload;
+            GameAPI.DayChange -= OnReload;
         }
 
         internal override void OnSceneLoaded(UnityEngine.SceneManagement.Scene scene, LoadSceneMode mode)
         {
-            OnReload();
+            OnReload(null, null);
         }
 
-        private void OnReload()
+        private void OnReload(object sender, EventArgs e)
         {
             _resetCamera = true;
         }


### PR DESCRIPTION
## Description
Sunshine camera isn't reset on period change of roaming mode, this adds it.

## How Has This Been Tested?
Works fine in Sunshine, certain it won't break OG koik.
