### PR TITLE
Fix compatibility with AnimationLoader

### DIFF
--- a/Shared/IK/AnimLoaderHelper.cs
+++ b/Shared/IK/AnimLoaderHelper.cs
@@ -42,11 +42,21 @@ namespace KK_VR.IK
                     continue;
                 }
 
-                var baseData = bendGoal.GetComponent<BaseData>();
-                if (baseData == null)
+                var bendGoalBaseData = bendGoal.GetComponent<BaseData>();
+                if (bendGoalBaseData == null)
                 {
-                    VRPlugin.Logger.LogWarning($"FBBIK(native) - {chara.name} - {bodyPart.name} doesn't have BaseData");
-                    continue;
+                    // We might have (most likely did) set in that field our own bend goal,
+                    // and it's now a child of the og bend goal.
+                    bendGoal = bendGoal.parent;
+
+                    if (bendGoal != null)
+                        bendGoalBaseData = bendGoal.GetComponent<BaseData>();
+
+                    if (bendGoalBaseData == null)
+                    {
+                        VRPlugin.Logger.LogWarning($"FBBIK(native) - {chara.name} - {bodyPart.name} doesn't have BaseData (bendGoal)");
+                        continue;
+                    }
                 }
 
                 var ikBeforeProcessBendGoal = bendGoal.GetComponent<IKBeforeProcess>();
@@ -56,13 +66,13 @@ namespace KK_VR.IK
                     continue;
                 }
 
-                baseData.bone = chara.objAnim.transform.Find(cf_pv_bones_bendGoals[i - 5]);
-                if (baseData.bone == null)
+                bendGoalBaseData.bone = chara.objAnim.transform.Find(cf_pv_bones_bendGoals[i - 5]);
+                if (bendGoalBaseData.bone == null)
                 {
                     VRPlugin.Logger.LogWarning($"Failed to find bendGoal bone at {cf_pv_bones_bendGoals[i - 5]}");
                     continue;
                 }
-                baseData.enabled = true;
+                bendGoalBaseData.enabled = true;
                 ikBeforeProcessBendGoal.enabled = true;
                 ikBeforeProcessBendGoal.type = BaseProcess.Type.Sync;
             }


### PR DESCRIPTION
<!--- If your change only affects some games or only one plugin out of multiple, 
      put this information in the title, e.g. "[ME][KK/KKS] Add a kitchen sink"-->

## Description
Fix the way vr plugin salvages IK setup on animations loaded via `AnimationLoader` plugin without IK data.

## Motivation and Context
An oversight brought forth by insufficient testing. It came in as obvious when recently I tried to use `AnimationLoader` plugin and some positions were pretty broken.

## How Has This Been Tested?
In both games, seems to work so far.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
